### PR TITLE
Add `useOverflow` hook and remove Google Tag Manager

### DIFF
--- a/basehub.d.ts
+++ b/basehub.d.ts
@@ -50,11 +50,11 @@ export interface Scalars {
 }))[],
     BSHBRichTextContentSchema: RichTextNode[],
     BSHBRichTextTOCSchema: RichTextTocNode[],
-    BSHBSelect_2048205991: 'Vida Nova' | 'Kírion' | 'Shedd Publicações' | 'Thomas Nelson Brasil' | 'Fiel' | 'Companhia das Letras' | 'Pro Nobis' | 'Cultura Cristã' | 'Pilgrim' | ' Genever Benning',
-    BSHBSelect_274798727: 'Dane C. Ortlund' | 'Robert Nystrom' | 'Timothy Keller' | 'James W. Sire' | 'Heber Campos Jr.' | 'Costa Neto' | 'John Piper' | 'A.-D. Sertillanges' | 'Russell P. Shedd' | 'Larry Crabb' | 'Sinclair B. Ferguson' | 'Kevin DeYoung' | 'John Bunyan',
-    BSHBSelect__462599322: 'Reading' | 'Finished',
-    BSHBSelect__635238408: 'Physical' | 'Digital',
-    BSHBSelect__949924030: 'Christian' | 'Apologetics' | 'Biography' | 'Education' | 'Family' | 'Fiction' | 'Finances' | 'Personal Development' | 'Philosophy' | 'Social & Political Science' | 'Software Engineering',
+    BSHBSelect_1461570115: 'Reading' | 'Finished',
+    BSHBSelect_346271021: 'Vida Nova' | 'Kírion' | 'Shedd Publicações' | 'Thomas Nelson Brasil' | 'Fiel' | 'Companhia das Letras' | 'Pro Nobis' | 'Cultura Cristã' | 'Pilgrim' | ' Genever Benning',
+    BSHBSelect__1049998026: 'Christian' | 'Apologetics' | 'Biography' | 'Education' | 'Family' | 'Fiction' | 'Finances' | 'Personal Development' | 'Philosophy' | 'Social & Political Science' | 'Software Engineering',
+    BSHBSelect__1414420368: 'Physical' | 'Digital',
+    BSHBSelect__1885717383: 'Dane C. Ortlund' | 'Robert Nystrom' | 'Timothy Keller' | 'James W. Sire' | 'Heber Campos Jr.' | 'Costa Neto' | 'John Piper' | 'A.-D. Sertillanges' | 'Russell P. Shedd' | 'Larry Crabb' | 'Sinclair B. Ferguson' | 'Kevin DeYoung' | 'John Bunyan',
     Boolean: boolean,
     CodeSnippetLanguage: B_Language,
     DateTime: any,
@@ -244,26 +244,26 @@ export interface BooksItem {
     _analyticsKey: Scalars['String']
     _dashboardUrl: Scalars['String']
     /** Array of search highlight information with field names and HTML markup */
-    _highlight: (SearchHighlight_Deq0JwtICPSdpUxrdsugH[] | null)
+    _highlight: (SearchHighlight_f2146f8fe10a8c3a119aa[] | null)
     _id: Scalars['String']
     _idPath: Scalars['String']
     _slug: Scalars['String']
     _slugPath: Scalars['String']
     _sys: BlockDocumentSys
     _title: Scalars['String']
-    authors: Scalars['BSHBSelect_274798727'][]
+    authors: Scalars['BSHBSelect__1885717383'][]
     cover: (BlockImage | null)
     edition: Scalars['Float']
     /** ISO 8601 date string. */
     finishedDate: (Scalars['String'] | null)
-    format: Scalars['BSHBSelect__635238408']
-    genres: Scalars['BSHBSelect__949924030'][]
+    format: Scalars['BSHBSelect__1414420368']
+    genres: Scalars['BSHBSelect__1049998026'][]
     progress: (Scalars['Float'] | null)
     publicationDate: Scalars['Float']
-    publisher: Scalars['BSHBSelect_2048205991'][]
+    publisher: Scalars['BSHBSelect_346271021'][]
     rating: (Scalars['Float'] | null)
     review: (Review | null)
-    status: Scalars['BSHBSelect__462599322']
+    status: Scalars['BSHBSelect_1461570115']
     subtitle: (Scalars['String'] | null)
     summary: (Summary | null)
     __typename: 'BooksItem'
@@ -587,12 +587,12 @@ export interface SearchHighlight_99e6d765742b93dae0e64 {
     __typename: 'SearchHighlight_99e6d765742b93dae0e64'
 }
 
-export interface SearchHighlight_Deq0JwtICPSdpUxrdsugH {
+export interface SearchHighlight_f2146f8fe10a8c3a119aa {
     /** The field/path that was matched (e.g., "title", "body.content") */
     by: Scalars['String']
     /** HTML snippet with <mark> tags around the matched terms */
     snippet: Scalars['String']
-    __typename: 'SearchHighlight_Deq0JwtICPSdpUxrdsugH'
+    __typename: 'SearchHighlight_f2146f8fe10a8c3a119aa'
 }
 
 export interface Settings {
@@ -1213,7 +1213,7 @@ export interface BooksItemGenqlSelection{
     scope?: (AnalyticsKeyScope | null)} } | boolean | number
     _dashboardUrl?: boolean | number
     /** Array of search highlight information with field names and HTML markup */
-    _highlight?: SearchHighlight_Deq0JwtICPSdpUxrdsugHGenqlSelection
+    _highlight?: SearchHighlight_f2146f8fe10a8c3a119aaGenqlSelection
     _id?: boolean | number
     _idPath?: boolean | number
     _slug?: boolean | number
@@ -1764,7 +1764,7 @@ export interface SearchHighlight_99e6d765742b93dae0e64GenqlSelection{
     __typename?: boolean | number
 }
 
-export interface SearchHighlight_Deq0JwtICPSdpUxrdsugHGenqlSelection{
+export interface SearchHighlight_f2146f8fe10a8c3a119aaGenqlSelection{
     /** The field/path that was matched (e.g., "title", "body.content") */
     by?: boolean | number
     /** HTML snippet with <mark> tags around the matched terms */
@@ -2406,9 +2406,9 @@ export interface FragmentsMap {
     root: SearchHighlight_99e6d765742b93dae0e64,
     selection: SearchHighlight_99e6d765742b93dae0e64GenqlSelection,
 }
-  SearchHighlight_Deq0JwtICPSdpUxrdsugH: {
-    root: SearchHighlight_Deq0JwtICPSdpUxrdsugH,
-    selection: SearchHighlight_Deq0JwtICPSdpUxrdsugHGenqlSelection,
+  SearchHighlight_f2146f8fe10a8c3a119aa: {
+    root: SearchHighlight_f2146f8fe10a8c3a119aa,
+    selection: SearchHighlight_f2146f8fe10a8c3a119aaGenqlSelection,
 }
   Settings: {
     root: Settings,

--- a/src/app/[lang]/reading/_components/book-genre-badge.tsx
+++ b/src/app/[lang]/reading/_components/book-genre-badge.tsx
@@ -12,6 +12,7 @@ export function BookGenreBadge(props: BookGenreBadgeProps) {
         fontSize: "xs",
         w: "fit-content",
         borderRadius: "md",
+        whiteSpace: "nowrap",
         fontWeight: "medium",
         alignItems: "center",
         display: "inline-flex",

--- a/src/app/[lang]/reading/_components/book-preview-card.tsx
+++ b/src/app/[lang]/reading/_components/book-preview-card.tsx
@@ -1,6 +1,11 @@
+"use client";
+
+import { useRef } from "react";
 import Image from "next/image";
+
 import { css } from "@/panda/css";
 import { flex, hstack, vstack } from "@/panda/patterns";
+import { useOverflow } from "@/app/_hooks/use-overflow";
 import { BookGenreBadge } from "@/app/[lang]/reading/_components/book-genre-badge";
 
 type BookPreviewCardProps = {
@@ -12,6 +17,9 @@ type BookPreviewCardProps = {
 };
 
 export function BookPreviewCard(props: BookPreviewCardProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const { isOverflowing, scrollPos } = useOverflow<HTMLDivElement>(ref);
+
   const bookProgress = props.progress ?? 0;
 
   return (
@@ -44,6 +52,7 @@ export function BookPreviewCard(props: BookPreviewCardProps) {
           px: 5,
           py: 4,
           flex: 1,
+          overflow: "hidden",
         })}
       >
         <div className={vstack({ gap: 3, alignItems: "stretch" })}>
@@ -72,8 +81,23 @@ export function BookPreviewCard(props: BookPreviewCardProps) {
             {props.authors.length === 0 ? "Unknown" : props.authors.join(", ")}
           </h4>
         </div>
-        <div className={vstack({ alignItems: "stretch" })}>
-          <div className={hstack({ gap: 2 })}>
+        <div className={vstack({ alignItems: "stretch", width: "full" })}>
+          <div
+            ref={ref}
+            className={hstack({
+              gap: 2,
+              ...(isOverflowing && {
+                p: 0.5,
+                overflowX: "scroll",
+                WebkitMaskImage: scrollPos.atEnd
+                  ? "none"
+                  : "linear-gradient(to right, black 75%, transparent 100%)",
+                maskImage: scrollPos.atEnd
+                  ? "none"
+                  : "linear-gradient(to right, black 75%, transparent 100%)",
+              }),
+            })}
+          >
             {props.genres.map((genre) => (
               <BookGenreBadge key={genre}>{genre}</BookGenreBadge>
             ))}

--- a/src/app/_hooks/use-overflow.ts
+++ b/src/app/_hooks/use-overflow.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+
+type UseOverflowOptions = Partial<{
+  horizontal: boolean;
+  vertical: boolean;
+}>;
+
+export function useOverflow<T extends HTMLElement>(
+  ref: React.RefObject<T | null>,
+  opts: UseOverflowOptions = {},
+) {
+  const { horizontal = true, vertical = false } = opts;
+  const [isOverflowing, setIsOverflowing] = useState(false);
+  const [scrollPos, setScrollPos] = useState({ atStart: true, atEnd: false });
+
+  useEffect(() => {
+    const el = ref.current;
+    if (el === null) return;
+
+    const compute = () => {
+      const h = horizontal ? el.scrollWidth > el.clientWidth : false;
+      const v = vertical ? el.scrollHeight > el.clientHeight : false;
+      setIsOverflowing(h || v);
+    };
+
+    const update = () => {
+      const maxScroll = el.scrollWidth - el.clientWidth;
+      const atStart = el.scrollLeft <= 1;
+      const atEnd = el.scrollLeft >= maxScroll - 1;
+      setScrollPos({ atStart, atEnd });
+    };
+
+    compute();
+    update();
+
+    el.addEventListener("scroll", update, { passive: true });
+
+    // Recompute on size/content changes
+    const ro = new ResizeObserver(compute);
+    ro.observe(el);
+
+    // If children change text/DOM
+    const mo = new MutationObserver(compute);
+    mo.observe(el, { childList: true, subtree: true, characterData: true });
+
+    // Recompute on window resize
+    const onResize = () => compute();
+    window.addEventListener("resize", onResize);
+
+    return () => {
+      ro.disconnect();
+      mo.disconnect();
+      window.removeEventListener("resize", onResize);
+    };
+  }, [horizontal, vertical]);
+
+  return { isOverflowing, scrollPos };
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
 import type { Metadata, Viewport } from "next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
-import { GoogleTagManager } from "@next/third-parties/google";
+
 import "@/ui/styles/base.css";
 import { css } from "@/panda/css";
 import { Provider } from "@/app/_components/provider";
@@ -77,7 +77,6 @@ export default function AppLayout(props: Readonly<React.PropsWithChildren>) {
         />
       </head>
       <body className={css({ fontFamily: "GeistSans" })}>
-        <GoogleTagManager gtmId="GTM-5CX6S9KJ" />
         <Provider>{props.children}</Provider>
         <SpeedInsights />
       </body>


### PR DESCRIPTION
This pull request includes the following changes:

- **Feature:** Introduced the `useOverflow` hook to handle genre overflow effectively, along with updated type definitions.
- **Refactor:** Removed the integration of Google Tag Manager from the layout. 

No breaking changes or additional configurations are required.